### PR TITLE
Prevent crashes when calling clear recursively

### DIFF
--- a/src/components/Airship.tsx
+++ b/src/components/Airship.tsx
@@ -65,8 +65,12 @@ export function makeAirship(): Airship {
     )
   }
 
+  let clearing = false
   function clear(): void {
+    if (clearing) return
+    clearing = true
     emitClear(undefined)
+    clearing = false
   }
 
   async function show<T>(render: AirshipRender<T>): Promise<T> {


### PR DESCRIPTION
Clients can run into infinite loops where clearing the Airship leads to more clear calls, and so forth. It can be tricky for clients to identify these cases if there are many layers of code involved (like React and Redux), so we can help prevent crashes by just ignoring calls to clear if we are in the middle of a clear call to begin with.