### PR TITLE
Trigger handleLayout an extra time to fix RN failures

### DIFF
--- a/src/components/Barometer.tsx
+++ b/src/components/Barometer.tsx
@@ -116,6 +116,10 @@ export function Barometer(props: Props): JSX.Element {
             offset: sidesToOffset(offset),
             padding: sidesToPadding(padding)
           })
+
+          // Force a second trigger because React Native can fail to invoke
+          // onLayout for some edge cases.
+          setTimeout(handleLayout, 2000)
         }
       })
       .catch(() => {})


### PR DESCRIPTION
React Native was not calling onLayout during rapid window transitions, so to mitigate this issue we include an extra call to the layout handler to force the layout to measure the correct state.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202709859964721